### PR TITLE
MON-936/Revert PHP 8.0 features

### DIFF
--- a/monek-checkout/Callback/CallbackController.php
+++ b/monek-checkout/Callback/CallbackController.php
@@ -10,7 +10,7 @@ class CallbackController
 
     private const GATEWAY_ID = 'monekgateway';
     
-    private IntegrityCorroborator $integrity_corroborator;
+    private $integrity_corroborator;
 
     /**
      * @param bool $is_test_mode_active

--- a/monek-checkout/Callback/IntegrityCorroborator.php
+++ b/monek-checkout/Callback/IntegrityCorroborator.php
@@ -7,13 +7,15 @@
  */
 class IntegrityCorroborator 
 {
+    private $is_test_mode_active;
 
     /**
      * @param bool $is_test_mode_active
      */
-    public function __construct(
-        private bool $is_test_mode_active
-        ) {}    
+    public function __construct(bool $is_test_mode_active) 
+    {
+        $this->is_test_mode_active = $is_test_mode_active;
+    }    
     
     /**
      * Confirm the integrity of the transaction data through an HTTP POST request to the Monek API 
@@ -22,7 +24,7 @@ class IntegrityCorroborator
      * @param WebhookPayload $transaction_webhook_payload_data
      * @return array|WP_Error
      */
-    public function confirm_integrity_digest(WC_Order $order, WebhookPayload $transaction_webhook_payload_data) : array|WP_Error
+    public function confirm_integrity_digest(WC_Order $order, WebhookPayload $transaction_webhook_payload_data)
     {
         $idempotency_token = get_post_meta($order->get_id(), 'idempotency_token', true);
         $integrity_secret = get_post_meta($order->get_id(), 'integrity_secret', true);

--- a/monek-checkout/Monek-Checkout.php
+++ b/monek-checkout/Monek-Checkout.php
@@ -5,7 +5,7 @@
  * Author: Monek Ltd
  * Author URI: http://www.monek.com
  * Description: Take credit/debit card payments with Monek.
- * Version: 3.1.0
+ * Version: 3.0.3
  * text-domain: monek-payment-gateway
  * Requires Plugins: woocommerce
  * License: GPLv3 or later
@@ -14,8 +14,8 @@
  * Contributors: Monek Ltd
  * Requires at least: 5.0
  * Tested up to: 6.0
- * Requires PHP: 8.0
- * Stable tag: 3.1.0
+ * Requires PHP: 7.4
+ * Stable tag: 3.0.3
  */
 
  /*

--- a/monek-checkout/Payment/PreparedPaymentManager.php
+++ b/monek-checkout/Payment/PreparedPaymentManager.php
@@ -7,12 +7,15 @@
  */
 class PreparedPaymentManager 
 {
+    private bool $is_test_mode_active;
+
     /**
      * @param bool $is_test_mode_active
      */
-    public function __construct(
-        private bool $is_test_mode_active
-        ) { }    
+    public function __construct(bool $is_test_mode_active) 
+    { 
+        $this->is_test_mode_active = $is_test_mode_active;
+    }    
 
     /**
      * Create a prepared payment request and send it to the payment gateway
@@ -25,7 +28,7 @@ class PreparedPaymentManager
      * @return array|WP_Error
      */
     public function create_prepared_payment(WC_Order $order, string $merchant_id,  string $country_code,  
-        string $return_plugin_url, string $purchase_description) : array|WP_Error
+        string $return_plugin_url, string $purchase_description)
     {
         if (!$this->verify_nonce()) {
             return new WP_Error('invalid_nonce', __('Invalid nonce', 'monek-payment-gateway'));
@@ -53,7 +56,7 @@ class PreparedPaymentManager
      * @param array $prepared_payment_request
      * @return array|WP_Error
      */
-    private function send_prepared_payment_request(array $prepared_payment_request) : array|WP_Error
+    private function send_prepared_payment_request(array $prepared_payment_request)
     {
         $prepared_payment_url = $this->get_ipay_prepare_url();
 
@@ -67,7 +70,8 @@ class PreparedPaymentManager
      *
      * @return bool
      */
-    private function verify_nonce() {
+    private function verify_nonce() : bool
+    {
         $nonce = filter_input(INPUT_POST, "woocommerce-process-checkout-nonce");
 
         if (!$nonce) {

--- a/monek-checkout/changelog.txt
+++ b/monek-checkout/changelog.txt
@@ -1,10 +1,10 @@
 *** Monek Checkout Changelog ***
 
-2024-08-23 version 3.1.0
+2024-08-23 version 3.0.3
 * Fixed - MON-936/Fixed-Security-Flags, Sanitized input fields (#13)
 * Fixed - MON-936/Fixed-Security-Flags, Changed to use wp_safe_redirect
 * Fixed - Mon-936/Fixed-Security-Flags, Changed root folder to match slug monek-checkout
-* Update - Updated to use new PHP 8.0 features and updated required PHP version
+* Update - Updated to use new PHP 7.4 features and updated required PHP version
 * Added - Added PHPDoc comments to classes and functions
 * Tweak - Extracted some logic into new classes and created new folder structure to uncrowd the root folder
 * Tweak - Cleaned up some of the naming conventions

--- a/monek-checkout/readme.txt
+++ b/monek-checkout/readme.txt
@@ -1,7 +1,7 @@
 === Monek Checkout ===
 Contributors: monek, humberstone83-x
 Tags: ecommerce, e-commerce, payment-method, payment-gateway, gateway
-Stable tag: 3.1.0
+Stable tag: 3.0.3
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Tested up to: 6.6.1


### PR DESCRIPTION
Looks like the automatic test runner that WooCommerce are using themselves is only running PHP 7.4. Sadly this means we will have to revert the 8.0 features in order to pass the initial WooCommerce review. None of the features are actually that important so reverting and we can continue to support 7.4 and above maximising our compatibility. 

Without the php 8.0 change i no longer thing this constitutes a major version bump, so changed to a minor increase. 