### PR TITLE
Mon 966/enable google pay setting

### DIFF
--- a/monek-checkout/MCWC_MonekGateway.php
+++ b/monek-checkout/MCWC_MonekGateway.php
@@ -110,8 +110,8 @@ class MCWC_MonekGateway extends WC_Payment_Gateway
                 'title' => __('Enable GooglePay', 'monek-checkout'),
                 'type' => 'checkbox',
                 'default' => 'no',
-                'label' => __('Enable GooglePay', 'monek-checkout'),
-                'description' => __('Enable this option to provide access to GooglePay as a payment option. Merchants must adhere to the Google Pay APIs Acceptable Use Policy and accept the terms defined in the Google Pay API Terms of Service.', 'monek-checkout'),
+                'label' => __('Enable this option to provide access to GooglePay as a payment option.', 'monek-checkout'),
+                'description' => __('Merchants must adhere to the <a href="https://payments.developers.google.com/terms/aup" target="_blank">Google Pay APIs Acceptable Use Policy</a> and accept the terms defined in the <a href="https://payments.developers.google.com/terms/sellertos" target="_blank">Google Pay API Terms of Service</a>.', 'monek-checkout'),
                 'desc_tip' => true
             ],
             'basket_summary' => [

--- a/monek-checkout/MCWC_MonekGateway.php
+++ b/monek-checkout/MCWC_MonekGateway.php
@@ -110,8 +110,7 @@ class MCWC_MonekGateway extends WC_Payment_Gateway
                 'title' => __('Enable GooglePay', 'monek-checkout'),
                 'type' => 'checkbox',
                 'default' => 'no',
-                'label' => __('Enable this option to provide access to GooglePay as a payment option.', 'monek-checkout'),
-                'description' => __('Merchants must adhere to the <a href="https://payments.developers.google.com/terms/aup" target="_blank">Google Pay APIs Acceptable Use Policy</a> and accept the terms defined in the <a href="https://payments.developers.google.com/terms/sellertos" target="_blank">Google Pay API Terms of Service</a>.', 'monek-checkout'),
+                'label' => __('Enable this option to provide access to GooglePay as a payment option. Merchants must adhere to the <a href="https://payments.developers.google.com/terms/aup" target="_blank">Google Pay APIs Acceptable Use Policy</a> and accept the terms defined in the <a href="https://payments.developers.google.com/terms/sellertos" target="_blank">Google Pay API Terms of Service</a>.', 'monek-checkout'),
                 'desc_tip' => true
             ],
             'basket_summary' => [

--- a/monek-checkout/MCWC_MonekGateway.php
+++ b/monek-checkout/MCWC_MonekGateway.php
@@ -21,6 +21,7 @@ class MCWC_MonekGateway extends WC_Payment_Gateway
     private bool $is_test_mode_active;
     public string $merchant_id;
     private MCWC_PreparedPaymentManager $prepared_payment_manager;
+    private bool $show_google_pay;
     public static string $staging_url = 'https://staging.monek.com/Secure/';
 
     public function __construct() 
@@ -32,7 +33,7 @@ class MCWC_MonekGateway extends WC_Payment_Gateway
 
         add_action("woocommerce_update_options_payment_gateways_{$this->id}", [$this, 'process_admin_options'] ); 
 
-        $this->prepared_payment_manager = new MCWC_PreparedPaymentManager($this->is_test_mode_active);
+        $this->prepared_payment_manager = new MCWC_PreparedPaymentManager($this->is_test_mode_active, $this->show_google_pay);
 
         $callback_controller = new MCWC_CallbackController($this->is_test_mode_active);
         $callback_controller->mcwc_register_routes();
@@ -60,6 +61,7 @@ class MCWC_MonekGateway extends WC_Payment_Gateway
 		$this->description = __('Pay securely with Monek.', 'monek-checkout');
         $this->merchant_id = $this->get_option( 'merchant_id' );
         $this->is_test_mode_active = isset($this->settings['test_mode']) && $this->settings['test_mode'] == 'yes';
+        $this->show_google_pay = isset($this->settings['google_pay']) && $this->settings['google_pay'] == 'yes';
         $this->country_dropdown = $this->get_option('country_dropdown');
         $this->basket_summary = $this->get_option('basket_summary');
     }
@@ -102,6 +104,14 @@ class MCWC_MonekGateway extends WC_Payment_Gateway
                 'default' => 'no',
                 'label' => __('Enable trial features', 'monek-checkout'),
                 'description' => __('Enable this option to access trial features. Trial features provide early access to new functionalities and enhancements that are currently in testing.', 'monek-checkout'),
+                'desc_tip' => true
+            ],
+            'google_pay' => [
+                'title' => __('Enable GooglePay', 'monek-checkout'),
+                'type' => 'checkbox',
+                'default' => 'no',
+                'label' => __('Enable GooglePay', 'monek-checkout'),
+                'description' => __('Enable this option to provide access to GooglePay as a payment option. Merchants must adhere to the Google Pay APIs Acceptable Use Policy and accept the terms defined in the Google Pay API Terms of Service.', 'monek-checkout'),
                 'desc_tip' => true
             ],
             'basket_summary' => [

--- a/monek-checkout/Monek-Checkout.php
+++ b/monek-checkout/Monek-Checkout.php
@@ -5,7 +5,7 @@
  * Author: Monek Ltd
  * Author URI: http://www.monek.com
  * Description: Take credit/debit card payments with Monek.
- * Version: 3.1.0
+ * Version: 3.2.0
  * text-domain: monek-checkout
  * Requires Plugins: woocommerce
  * License: GPLv3 or later
@@ -15,7 +15,7 @@
  * Requires at least: 5.0
  * Tested up to: 6.6.1
  * Requires PHP: 7.4
- * Stable tag: 3.1.0
+ * Stable tag: 3.2.0
  */
 
  /*

--- a/monek-checkout/Payment/MCWC_PreparedPaymentManager.php
+++ b/monek-checkout/Payment/MCWC_PreparedPaymentManager.php
@@ -8,13 +8,15 @@
 class MCWC_PreparedPaymentManager 
 {
     private bool $is_test_mode_active;
+    private bool $show_google_pay;
 
     /**
      * @param bool $is_test_mode_active
      */
-    public function __construct(bool $is_test_mode_active) 
+    public function __construct(bool $is_test_mode_active, bool $show_google_pay) 
     { 
         $this->is_test_mode_active = $is_test_mode_active;
+        $this->show_google_pay = $show_google_pay;
     }    
 
     /**
@@ -33,7 +35,7 @@ class MCWC_PreparedPaymentManager
         if (!$this->mcwc_verify_nonce()) {
             return new WP_Error('invalid_nonce', __('Invalid nonce', 'monek-checkout'));
         }
-        $request_builder = new MCWC_PreparedPaymentRequestBuilder();
+        $request_builder = new MCWC_PreparedPaymentRequestBuilder($this->show_google_pay);
         $prepared_payment_request = $request_builder->mcwc_build_request($order, $merchant_id, $country_code, $return_plugin_url, $purchase_description);
 
         return $this->mcwc_send_prepared_payment_request($prepared_payment_request);

--- a/monek-checkout/Payment/MCWC_PreparedPaymentRequestBuilder.php
+++ b/monek-checkout/Payment/MCWC_PreparedPaymentRequestBuilder.php
@@ -9,6 +9,13 @@ class MCWC_PreparedPaymentRequestBuilder
 {    
     private const PARTIAL_ORIGIN_ID = 'a6c921f4-8e00-4b11-99f4-';
 
+    private bool $show_google_pay;
+
+    public function __construct($show_google_pay) 
+    {
+        $this->show_google_pay = $show_google_pay;
+    }
+
     /**
      * Build the prepared payment request for the payment gateway
      *
@@ -45,8 +52,9 @@ class MCWC_PreparedPaymentRequestBuilder
             'IntegritySecret' => get_post_meta($order->get_id(), 'integrity_secret', true),
             'Basket' => $this->mcwc_generate_basket_base64($order),
             'ShowDeliveryAddress' => 'YES',
+            'ShowGooglePay' => $this->show_google_pay ? 'YES' : 'NO',
             'WPNonce' => wp_create_nonce('complete-payment_' . $order->get_id()),
-            'Callback' => 'true'
+            'Callback' => 'true',
         ];
 
         return $this->mcwc_generate_cardholder_detail_information($prepared_payment_request);

--- a/monek-checkout/changelog.txt
+++ b/monek-checkout/changelog.txt
@@ -1,5 +1,8 @@
 *** Monek Checkout Changelog ***
 
+2024-09-09 version 3.2.0
+* Added - Added a new feature to allow the user to enable GooglePay as a payment method
+
 2024-08-28 version 3.1.0
 * Update - Updated text-domain to match slug. Updated text-domain in all files
 * Added - Added additional sanitisations to input fields

--- a/monek-checkout/readme.txt
+++ b/monek-checkout/readme.txt
@@ -1,7 +1,7 @@
 === Monek Checkout ===
 Contributors: monek, humberstone83-x
 Tags: ecommerce, e-commerce, payment-method, payment-gateway, gateway
-Stable tag: 3.1.0
+Stable tag: 3.2.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Tested up to: 6.6.1
@@ -31,3 +31,13 @@ Customers can now securely pay using credit and debit cards via Monek.
 Note: If you do not have a Monek ID, please visit Monek's website to sign up and obtain your ID. For any assistance with setup or integration, contact Monek directly through their website.
 
 Experience the future of payment processing with Monek � where simplicity meets sophistication.
+
+== Configuration ==
+
+GooglePay: 
+
+Indicates if the Google Pay™ button will appear on the checkout page. `YES` or `NO` (default)
+
+All merchants must adhere to the Google Pay APIs [Acceptable Use Policy](https://payments.developers.google.com/terms/aup) and accept the terms defined in the [Google Pay API Terms of Service](https://payments.developers.google.com/terms/sellertos). 
+
+Google Pay is a trademark of Google LLC.


### PR DESCRIPTION
### Google Pay Setting Added to WooCommerce Plugin

We have added a new setting to the **WooCommerce Plugin** page that allows merchants to enable Google Pay as a checkout option. The default value for this setting is set to `false`.

Key details:
- **Clear communication**: We provide visible links on the page, ensuring merchants understand the terms and conditions they are agreeing to when enabling Google Pay.
- **Default setting**: The Google Pay option is disabled by default (`false`).
- **Configuration behavior**: When this setting is enabled (`true`), the `ShowGooglePay` configuration will be sent with a `YES` value.

This update ensures merchants have clear control over the Google Pay integration and are informed of all related conditions before activation.


![image](https://github.com/user-attachments/assets/e660a8f3-bde0-418a-ab80-18982857e6f2)
